### PR TITLE
Delete useless sub-repo.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "unintended-ml-bias-analysis"]
-	path = unintended-ml-bias-analysis
-	url = https://github.com/conversationai/unintended-ml-bias-analysis.git


### PR DESCRIPTION
I originally thought that the repo unintended-ml-bias-analysis contained a baseline repo based on the Kaggle description, but that seems to not be the case. Removing it to reduce cluttering.